### PR TITLE
fix: display archived message attachments correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To update your bot permissions, scopes and intents, please head to [Discord Deve
 
 - Your bot will be required at least these permissions and scopes in order to work properly
 
-![bot permissions](https://i.imgur.com/d40dqH7.png)
+![bot permissions](https://i.imgur.com/GXdmcq3.png)
 
 - Your bot should also have these intents enabled
 

--- a/src/libs/CoMoBot.ts
+++ b/src/libs/CoMoBot.ts
@@ -17,6 +17,7 @@ export class CoMoBot extends Client {
                 Intents.FLAGS.GUILD_MESSAGES,
                 Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
                 Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS,
+                Intents.FLAGS.GUILD_WEBHOOKS,
                 Intents.FLAGS.DIRECT_MESSAGES,
                 Intents.FLAGS.DIRECT_MESSAGE_REACTIONS
             ],

--- a/src/libs/ReportTicket.ts
+++ b/src/libs/ReportTicket.ts
@@ -5,7 +5,7 @@ export class ReportTicket {
     public readonly id: number;
     public readonly user: User;
     public userDMChannel: DMChannel;
-    public userDescription?: string;
+    public userDescriptionMessage?: Message;
     public case?: "report" | "emergency";
     private readonly createByReaction: boolean = false;
     public readonly createTime: Date = new Date();


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
Closes #18 

Additional description:
Bot now also requires Manage webhooks and Attach files permission, as it sends the archived message and user description as webhook with their attachments. This is because we can't send attachments in embed messages.