### PR TITLE
feat: set of commands to dynamically create/delete/modify voice channels as needed

### DIFF
--- a/src/commands/voice.ts
+++ b/src/commands/voice.ts
@@ -1,0 +1,53 @@
+import {Command} from "../libs/Command";
+import {SlashCommandBuilder} from "@discordjs/builders";
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName("voice")
+        .setDescription("Commands for voice channel")
+        .addSubcommand(command => command
+            .setName("create")
+            .setDescription("Create a new voice channel")
+            .addStringOption(option => option
+                .setName("name")
+                .setDescription("Name for the voice channel")
+                .setRequired(true)))
+        .addSubcommand(command => command
+            .setName("set_category")
+            .setDescription("Set category channel for voice")
+            .addChannelOption(option => option
+                .setName("category_channel")
+                .setDescription("The category channel for voice")
+                .setRequired(true)))
+        .addSubcommand(command => command
+            .setName("close")
+            .setDescription("Close your voice channel")
+            .addChannelOption(option => option
+                .setName("voice_channel")
+                .setDescription("close this voice channel (Admin only option)")))
+        .addSubcommand(command => command
+            .setName("change_name")
+            .setDescription("Change name of your voice channel")
+            .addStringOption(option => option
+                .setName("name")
+                .setDescription("New name for the voice channel")
+                .setRequired(true))
+            .addChannelOption(option => option
+                .setName("voice_channel")
+                .setDescription("set name of this voice channel (Admin only option)")))
+        .addSubcommand(command => command
+            .setName("change_limit")
+            .setDescription("Change user amount limit of your voice channel")
+            .addIntegerOption(option => option
+                .setName("limit")
+                .setDescription("amount of user limit of the voice channel")
+                .setMinValue(2)
+                .setMaxValue(42)
+                .setRequired(true))
+            .addChannelOption(option => option
+                .setName("voice_channel")
+                .setDescription("set the user amount limit for this voice channel (Admin only option)"))),
+    run: async ({client, interaction}) => {
+        await client.voiceManager.handleCommand(interaction);
+    }
+});

--- a/src/libs/CoMoBot.ts
+++ b/src/libs/CoMoBot.ts
@@ -18,6 +18,7 @@ export class CoMoBot extends Client {
                 Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
                 Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS,
                 Intents.FLAGS.GUILD_WEBHOOKS,
+                Intents.FLAGS.GUILD_VOICE_STATES,
                 Intents.FLAGS.DIRECT_MESSAGES,
                 Intents.FLAGS.DIRECT_MESSAGE_REACTIONS
             ],

--- a/src/libs/CoMoBot.ts
+++ b/src/libs/CoMoBot.ts
@@ -4,11 +4,13 @@ import * as fs from 'fs';
 import path from "path";
 import {ReportManager} from "./ReportManager";
 import {Command} from "./Command";
+import {VoiceManager} from "./VoiceManager";
 
 export class CoMoBot extends Client {
     public readonly commands: Collection<string, Command> = new Collection<string, Command>();
     public readonly config: CoMoBotConfig;
     public readonly reportManager: ReportManager;
+    public readonly voiceManager: VoiceManager;
 
     constructor(config: CoMoBotConfig) {
         super({
@@ -26,6 +28,7 @@ export class CoMoBot extends Client {
         });
         this.config = config;
         this.reportManager = new ReportManager({client: this, expireTime: 5 * 60 * 1000});
+        this.voiceManager = new VoiceManager({client: this, deletionDelay: 30 * 60 * 1000});
     }
 
     public async start() {
@@ -87,5 +90,6 @@ export class CoMoBot extends Client {
         }
 
         this.on("messageReactionAdd", this.reportManager.messageReactionAddHandler.bind(this.reportManager));
+        this.on("voiceStateUpdate", this.voiceManager.voiceStateUpdateHandler.bind(this.voiceManager));
     }
 }

--- a/src/libs/VoiceManager.ts
+++ b/src/libs/VoiceManager.ts
@@ -1,0 +1,164 @@
+import {CoMoBot} from "./CoMoBot";
+import {
+    Collection,
+    Permissions,
+    CategoryChannel,
+    CommandInteraction,
+    VoiceChannel,
+    VoiceState,
+} from "discord.js";
+import {VoiceManagerOptions} from "./types";
+
+export class VoiceManager {
+    private readonly client: CoMoBot;
+    private readonly voiceCategoryChannel: Collection<string, CategoryChannel> = new Collection<string, CategoryChannel>();
+    private readonly voiceChannels: Collection<string, Array<VoiceChannel>> = new Collection<string, Array<VoiceChannel>>();
+    private readonly deletionDelay: number = 30 * 60 * 1000;
+
+    constructor(voiceManagerOptions: VoiceManagerOptions) {
+        this.client = voiceManagerOptions.client;
+        if (voiceManagerOptions.deletionDelay) this.deletionDelay = voiceManagerOptions.deletionDelay;
+    }
+
+    public async voiceStateUpdateHandler(oldState: VoiceState, newState: VoiceState) {
+        if (newState.channel) return;
+        const voiceChannel = oldState.channel;
+        if (!voiceChannel || !(voiceChannel instanceof VoiceChannel)) return;
+        if (voiceChannel.members.first()) return;
+        if (!this.voiceChannels.find(arr => arr.includes(voiceChannel))) return;
+        this.delayVoiceDeletion(voiceChannel);
+    }
+
+    public async handleCommand(interaction: CommandInteraction) {
+        if (!interaction.inGuild())
+            return await interaction.reply({content:"This command can only be used in a server!", ephemeral: true});
+
+        switch (interaction.options.getSubcommand()) {
+            case "create":
+                await this.createVoiceChannel(interaction);
+                break;
+            case "set_category":
+                await this.setCategoryChannel(interaction);
+                break;
+            case "close":
+                await this.closeVoiceChannel(interaction);
+                break;
+            case "change_name":
+                await this.changeChannelName(interaction);
+                break;
+            case "change_limit":
+                await this.changeChannelUserLimit(interaction);
+                break;
+            default:
+                return await interaction.reply({content:"Something went wrong!", ephemeral:true});
+        }
+    }
+
+    private async createVoiceChannel(interaction: CommandInteraction) {
+        const guildId = interaction.guildId!;
+        if (!this.voiceCategoryChannel.has(guildId))
+            return await interaction.reply({content:"Category channel for voice channel hasn't been set, please contact admin of the server!", ephemeral:true});
+
+        if (this.voiceChannels.get(interaction.user.id)?.at(0) && !interaction.memberPermissions!.has(Permissions.FLAGS.ADMINISTRATOR))
+            return await interaction.reply({content:"You already have a voice channel, please close that one before create new one", ephemeral:true});
+
+        let voiceChannel = await this.voiceCategoryChannel.get(guildId)!.createChannel(
+            interaction.options.getString("name")!,
+            {type:"GUILD_VOICE"}
+            ).catch(async () => {
+                await interaction.reply({content:"Failed to create channel!", ephemeral:true});
+        });
+        if (!voiceChannel) return;
+
+        this.voiceChannels.ensure(interaction.user.id, () => {return []}).push(voiceChannel);
+        await interaction.reply({content:`Successfully create ${interaction.options.getString("name")} voice channel.`});
+        this.delayVoiceDeletion(voiceChannel);
+    }
+
+    private async setCategoryChannel(interaction: CommandInteraction) {
+        if (!interaction.memberPermissions!.has(Permissions.FLAGS.ADMINISTRATOR))
+            return await interaction.reply({content:"You don't have permission to use this command!", ephemeral:true});
+
+        const categoryChannel = interaction.options.getChannel("category_channel");
+        if (!(categoryChannel instanceof CategoryChannel))
+            return await interaction.reply({content:"This channel isn't a category channel!", ephemeral:true});
+
+        this.voiceCategoryChannel.set(interaction.guildId!, categoryChannel);
+        await interaction.reply({content:`Successfully set ${categoryChannel.name} category channel for voice.`})
+    }
+
+    private async closeVoiceChannel(interaction: CommandInteraction) {
+        let voiceChannel = interaction.options.getChannel("voice_channel");
+        if (voiceChannel && !(voiceChannel instanceof VoiceChannel))
+            return await interaction.reply({content:"This channel isn't a voice channel!", ephemeral:true});
+
+        if (voiceChannel && !this.voiceChannels.get(interaction.user.id)?.includes(voiceChannel) && !interaction.memberPermissions!.has(Permissions.FLAGS.ADMINISTRATOR))
+            return await interaction.reply({content:"This voice channel isn't yours!", ephemeral:true});
+        if (!voiceChannel && !this.voiceChannels.get(interaction.user.id)?.at(0))
+            return await interaction.reply({content:"You don't own any voice channel!", ephemeral:true});
+        if (!voiceChannel)
+            voiceChannel = this.voiceChannels.get(interaction.user.id)!.pop()!;
+
+        this.voiceChannels.forEach((arr, key) => {
+            this.voiceChannels.set(key, arr.filter(_channel => _channel.id != voiceChannel!.id));
+        });
+        try {
+            await voiceChannel.delete();
+        } catch {
+            return await interaction.reply({content: "Failed to delete channel!", ephemeral:true});
+        }
+        await interaction.reply({content:`Successfully close ${voiceChannel.name} voice channel.`});
+    }
+
+    private delayVoiceDeletion(voiceChannel: VoiceChannel) {
+        setTimeout(async () => {
+            if (!voiceChannel.deletable) return;
+            if (voiceChannel.members.first()) return;
+            if (!this.voiceChannels.find(arr => arr.includes(voiceChannel))) return;
+            this.voiceChannels.forEach((arr, key) => {
+                this.voiceChannels.set(key, arr.filter(_channel => _channel.id != voiceChannel.id));
+            });
+            try { await voiceChannel.delete();} catch {}
+        }, this.deletionDelay);
+    }
+
+    private async changeChannelName(interaction: CommandInteraction) {
+        let voiceChannel = interaction.options.getChannel("voice_channel");
+        if (voiceChannel && !(voiceChannel instanceof VoiceChannel))
+            return await interaction.reply({content:"This channel isn't a voice channel!", ephemeral:true});
+
+        if (voiceChannel && !this.voiceChannels.get(interaction.user.id)?.includes(voiceChannel) && !interaction.memberPermissions!.has(Permissions.FLAGS.ADMINISTRATOR))
+            return await interaction.reply({content:"This voice channel isn't yours!", ephemeral:true});
+        if (!voiceChannel && !this.voiceChannels.get(interaction.user.id)?.at(0))
+            return await interaction.reply({content:"You don't own any voice channel!", ephemeral:true});
+        if (!voiceChannel)
+            voiceChannel = this.voiceChannels.get(interaction.user.id)!.at(0)!;
+
+        try {
+            await voiceChannel.setName(interaction.options.getString("name")!);
+        } catch {
+            return await interaction.reply({content: "Failed to change channel's name!", ephemeral:true});
+        }
+        await interaction.reply({content:`Successfully changes voice channel to ${voiceChannel.name}.`});
+    }
+
+    private async changeChannelUserLimit(interaction: CommandInteraction) {
+        let voiceChannel = interaction.options.getChannel("voice_channel");
+        if (voiceChannel && !(voiceChannel instanceof VoiceChannel))
+            return await interaction.reply({content:"This channel isn't a voice channel!", ephemeral:true});
+
+        if (voiceChannel && !this.voiceChannels.get(interaction.user.id)?.includes(voiceChannel) && !interaction.memberPermissions!.has(Permissions.FLAGS.ADMINISTRATOR))
+            return await interaction.reply({content:"This voice channel isn't yours!", ephemeral:true});
+        if (!voiceChannel && !this.voiceChannels.get(interaction.user.id)?.at(0))
+            return await interaction.reply({content:"You don't own any voice channel!", ephemeral:true});
+        if (!voiceChannel)
+            voiceChannel = this.voiceChannels.get(interaction.user.id)!.at(0)!;
+
+        try {
+            await voiceChannel.setUserLimit(interaction.options.getInteger("limit")!);
+        } catch {
+            return await interaction.reply({content: "Failed to change channel's user amount limit!", ephemeral:true});
+        }
+        await interaction.reply({content:`Successfully changes user amount limit to ${voiceChannel.name}.`});
+    }
+}

--- a/src/libs/types.ts
+++ b/src/libs/types.ts
@@ -53,6 +53,11 @@ export interface ReportManagerOptions {
     readonly expireTime?: number;
 }
 
+export interface VoiceManagerOptions {
+    readonly client: CoMoBot;
+    readonly deletionDelay?: number;
+}
+
 export interface CoMoBotConfig {
     readonly botToken: string;
     readonly guildIDs: string[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

At the moment in the 42 Wolfsburg discord the Auto Channel bots are not very **consistent**. This PR aims to address this problem by adding a new set of commands that has similar functionality.

These commands are: () for requirement, [] for optional
`/voice set_category (channel)` : set the Category Channel where the voice channels will be created under (Admin only command)
`/voice create (name)` : create new voice channel that belongs to that user, user can only have one concurrent voice channel
`/voice close [channel]` : close the voice channel belongs to the user. Optionally admin can close any voice channel they want
`/voice change_name (name) [channel]` : change name of the voice channel belongs to the user. Optionally admin can change name of any voice channel they want
`/voice change_limit (limit) [channel]` : change user amount limit of the voice channel belongs to the user. Optionally admin can change user amount limit of any voice channel they want

Bot will also listen to voiceState event and automatically close the inactive voice channel after 30 minutes.